### PR TITLE
Fix for issue 52: better handling of metrics with multiple availabilities by the Get-PureOneMetric command

### DIFF
--- a/PureStorage.Pure1.psd1
+++ b/PureStorage.Pure1.psd1
@@ -4,7 +4,7 @@
 	 Created by:   	Cody Hosterman
 	 Organization: 	Pure Storage, Inc.
 	 Filename:     	Cody.PureStorage.Pure1.psd1
-	 Version:		1.4.4.2
+	 Version:		1.4.4.3
 	 Copyright:		2022 Pure Storage, Inc.
 	-------------------------------------------------------------------------
 	 Module Name: PureStoragePure1PowerShell
@@ -30,7 +30,7 @@
 	RootModule = 'PureStorage.Pure1.psm1'
 	
 	# Version number of this module; major.minor[.build[.revision]]
-	ModuleVersion = '1.4.4.2'
+	ModuleVersion = '1.4.4.3'
 	
 	# ID used to uniquely identify this module
 	GUID = '65867a33-8c09-4651-8043-96c2f7ca2893'

--- a/PureStorage.Pure1.psm1
+++ b/PureStorage.Pure1.psm1
@@ -1947,9 +1947,9 @@ function Get-PureOneMetric {
       if ($granularity -eq 0)
       {
           if ($metricDetails.availabilities.Count -gt 1) {
-              #some of the metrics have multiple availabilities defined.
+              #some of the metrics have multiple availabilities defined
               #caller needs to specify metric granularity explicitly through the input parameters in this case
-              throw "Multiple granularities are available for the metric $($metricDetails.name). Specify the target granularity explicitly and re-run the command."
+              throw "Multiple granularities are available for the metric $($metricDetails.name). Specify the desired granularity explicitly, and re-run the command."
           }
           else {
              $granularity = $metricDetails.availabilities.resolution
@@ -1961,9 +1961,9 @@ function Get-PureOneMetric {
       if ($null -eq $startTime)
       {
           if ($metricDetails.availabilities.Count -gt 1) {
-              #some of the metrics have multiple availabilities defined.
+              #some of the metrics have multiple availabilities defined
               #caller needs to specify metric history start time explicitly through the input parameters in this case
-              throw "Multiple granularities and history time ranges are available for the metric $($metricDetails.name). Specify the target start time explicitly and re-run the command."
+              throw "Multiple granularities and history time ranges are available for the metric $($metricDetails.name). Specify the desired start time explicitly, and re-run the command."
           }
           else {
             $startTime = $epoch.AddMilliseconds($metricDetails._as_of - $metricDetails.availabilities[0].retention)

--- a/PureStorage.Pure1.psm1
+++ b/PureStorage.Pure1.psm1
@@ -1946,8 +1946,35 @@ function Get-PureOneMetric {
       #set granularity if not set
       if ($granularity -eq 0)
       {
-          $granularity = $metricDetails.availabilities.resolution
+          if ($metricDetails.availabilities.Count -gt 1) {
+              #some of the metrics have multiple availabilities defined.
+              #caller needs to specify metric granularity explicitly through the input parameters in this case
+              throw "Multiple granularities are available for the metric $($metricDetails.name). Specify the target granularity explicitly and re-run the command."
+          }
+          else {
+             $granularity = $metricDetails.availabilities.resolution
+          }
       }
+
+      [datetime]$epoch = '1970-01-01 00:00:00'
+      #set start time to current time (if not entered) and convert to epoch time
+      if ($null -eq $startTime)
+      {
+          if ($metricDetails.availabilities.Count -gt 1) {
+              #some of the metrics have multiple availabilities defined.
+              #caller needs to specify metric history start time explicitly through the input parameters in this case
+              throw "Multiple granularities and history time ranges are available for the metric $($metricDetails.name). Specify the target start time explicitly and re-run the command."
+          }
+          else {
+            $startTime = $epoch.AddMilliseconds($metricDetails._as_of - $metricDetails.availabilities[0].retention)
+          }
+      }
+      else {
+          $startTime = $startTime.ToUniversalTime()
+      }
+
+      $startEpoch = (New-TimeSpan -Start $epoch -End $startTime).TotalMilliSeconds
+      $startEpoch = [math]::Round($startEpoch)
 
       #set end time to start time minus retention for that stat (if not entered) and convert to epoch time
       if ($null -eq $endTime)
@@ -1958,20 +1985,8 @@ function Get-PureOneMetric {
       else {
           $endTime = $endTime.ToUniversalTime()
       }
-      [datetime]$epoch = '1970-01-01 00:00:00'
       $endEpoch = (New-TimeSpan -Start $epoch -End $endTime).TotalMilliSeconds
       $endEpoch = [math]::Round($endEpoch)
-
-      #set start time to current time (if not entered) and convert to epoch time
-      if ($null -eq $startTime)
-      {
-          $startTime = $epoch.AddMilliseconds($metricDetails._as_of - $metricDetails.availabilities.retention)
-      }
-      else {
-          $startTime = $startTime.ToUniversalTime()
-      }
-      $startEpoch = (New-TimeSpan -Start $epoch -End $startTime).TotalMilliSeconds
-      $startEpoch = [math]::Round($startEpoch)
 
       #building query
       if ($average -eq $true)
@@ -2651,6 +2666,7 @@ function Get-PureOneArrayLoadMeter {
       #set granularity if not set
       if ($granularity -eq 0)
       {
+          #only one availability is defined for the array_total_load metric at the moment
           $granularity = $metricDetails.availabilities.resolution
       }
 
@@ -2670,6 +2686,7 @@ function Get-PureOneArrayLoadMeter {
       #set start time to current time (if not entered) and convert to epoch time
       if ($startTime -eq $null)
       {
+          #only one availability is defined for the array_total_load metric at the moment
           $startTime = $epoch.AddMilliseconds($metricDetails._as_of - $metricDetails.availabilities.retention)
       }
       else {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@
 <!-- /wp:list -->
 
 <!-- wp:heading -->
+<h2>Latest version 1.4.4.3 (July 21st, 2022)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>See version details:<a href="https://github.com/PureStorage-OpenConnect/PureStorage.Pure1/issues/52"> https://github.com/PureStorage-OpenConnect/PureStorage.Pure1/issues/52</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>New features:</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Bug Fixes:</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>Enhanced handling of metrics with multiple availabilities by the Get-PureOneMetric command</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:heading -->
 <h2>Latest version 1.4.4.1 (June 2nd, 2021)</h2>
 <!-- /wp:heading -->
 


### PR DESCRIPTION
If a metric requested with Get-PureOneMetric has multiple availabilities defined and no metric granularity and/or start time were provided via the input parameters, the call fails with the corresponding failure message.
If a metric has just one availability defined, granularity and start time defined there might be used as defaults of no granularity and/or start time were provided via the input parameters.